### PR TITLE
Cgreene rev 20250113

### DIFF
--- a/src-ls/postgres-convention/async.md
+++ b/src-ls/postgres-convention/async.md
@@ -30,4 +30,4 @@ Here are the steps to perform an asynchronous operation:
 
 ## Details
 
-Table: stk_async;stk_async_type
+Table: `stk_async`;`stk_async_type`

--- a/src-ls/postgres-convention/column-convention.md
+++ b/src-ls/postgres-convention/column-convention.md
@@ -1,7 +1,7 @@
 # Column Convention
 
-- primary key `uu` - All tables have a single primary key named `uu`. 
-- foreign keys `_uu` suffix - example `stk_some_other_table_uu`. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix. Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
+- primary key `_uu` - All tables have a single primary key named `[table name]_uu`. 
+- foreign keys `_uu` suffix - example `stk_some_other_table_uu`. This means that the primary key column of a table, and the foreign key columns on other tables share a column name by default. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix, preferably on all references to the foreign table. It is acceptable for Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
 - noun first column name - when naming columns the noun comes first and the adjective comes next. Example: stk_wf_state_next_uu where state is the noun and next is the adjective. The benefit of this approach is that like columns (and the resulting methods/calls) appear next to each other alphabetically. 
 - text column - use columns of type `text` (instead of varchar with unspecified length). Only choose a varchar with a specific length when there is a compelling reason to do so. Even then try not to...
 - boolean column - boolean values must have a default value defined at the table level.

--- a/src-ls/postgres-convention/column-convention.md
+++ b/src-ls/postgres-convention/column-convention.md
@@ -1,7 +1,7 @@
 # Column Convention
 
-- primary key `_uu` - All tables have a single primary key named `<table name>_uu`. 
-- foreign keys `_uu` suffix - example `stk_some_other_table_uu`. This means that the primary key column of a table, and the foreign key columns on other tables share a column name by default. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix, preferably on all references to the foreign table. It is acceptable for Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
+- primary key `uu` - All tables have a single primary key named `uu`. 
+- foreign keys `_uu` suffix - example `stk_some_other_table_uu`. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix, preferably on all references to the foreign table. Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
 - noun first column name - when naming columns the noun comes first and the adjective comes next. Example: stk_wf_state_next_uu where state is the noun and next is the adjective. The benefit of this approach is that like columns (and the resulting methods/calls) appear next to each other alphabetically. 
 - text column - use columns of type `text` (instead of varchar with unspecified length). Only choose a varchar with a specific length when there is a compelling reason to do so. Even then try not to...
 - boolean column - boolean values must have a default value defined at the table level.

--- a/src-ls/postgres-convention/column-convention.md
+++ b/src-ls/postgres-convention/column-convention.md
@@ -1,6 +1,6 @@
 # Column Convention
 
-- primary key `_uu` - All tables have a single primary key named `[table name]_uu`. 
+- primary key `_uu` - All tables have a single primary key named `<table name>_uu`. 
 - foreign keys `_uu` suffix - example `stk_some_other_table_uu`. This means that the primary key column of a table, and the foreign key columns on other tables share a column name by default. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix, preferably on all references to the foreign table. It is acceptable for Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
 - noun first column name - when naming columns the noun comes first and the adjective comes next. Example: stk_wf_state_next_uu where state is the noun and next is the adjective. The benefit of this approach is that like columns (and the resulting methods/calls) appear next to each other alphabetically. 
 - text column - use columns of type `text` (instead of varchar with unspecified length). Only choose a varchar with a specific length when there is a compelling reason to do so. Even then try not to...

--- a/src-ls/postgres-convention/column-convention.md
+++ b/src-ls/postgres-convention/column-convention.md
@@ -3,7 +3,7 @@
 - primary key `uu` - All tables have a single primary key named `uu`. 
 - foreign keys `_uu` suffix - example `stk_some_other_table_uu`. There are times when this convention is not possible due to multiple references to the same table. When a duplicate is needed, add an adjective before the `_uu` suffix. Examples: `stk_bp_ship_to_uu` and `stk_bp_bill_to_uu`.
 - noun first column name - when naming columns the noun comes first and the adjective comes next. Example: stk_wf_state_next_uu where state is the noun and next is the adjective. The benefit of this approach is that like columns (and the resulting methods/calls) appear next to each other alphabetically. 
-- text column - use columns of type text (instead of varchar with unspecified length). Only choose a varchar with a specific length when there is a compelling reason to do so. Even then try not to...
+- text column - use columns of type `text` (instead of varchar with unspecified length). Only choose a varchar with a specific length when there is a compelling reason to do so. Even then try not to...
 - boolean column - boolean values must have a default value defined at the table level.
 - unique index - when creating unique index constraints, name the constraint using the table_name_column_name_uidx where `_uidx` represents the term unique index.
 
@@ -16,7 +16,7 @@ The purpose of this section is to list the columns that appear in every table th
 
 - primary key - `uu`
 - `stk_entity_uu` - financial set of books that owns the record
-- `created` - timestamptz indicating when the record was created.
+- `created` - `timestamptz` indicating when the record was created.
 - `created_by_uu` - uuid foreign key reference to the database user/role that created the record.
 - `updated` - timestamptz indicating when the record was last updated.
 - `updated_by_uu` - uuid foreign key reference to the database user/role that last updated the record.
@@ -32,11 +32,11 @@ Notes:
 The purpose of this section is to list the columns you commonly find in chuck-stack tables. Many of the below columns are used in the [sample table](./sample-table-convention.md).
 
 - `is_active` - boolean that indicates if a record can be modified. is_active also acts as a soft-delete. If a record has an is_active=false, the record should be be returned as an option for selection in future lists and drop down fields. This column must be present to update it after the initial save; therefore, it appears in most tables.
-- `name` - text representing the name of the record.
-- `description` - text representing the description of the record.
-- `search_key` - user defined text. The purpose of this column is to allow users to create keys that are more easily remembered by humans. It is up to the implementor to determine if the search_key should be unique for any given table. If it should be unique, the implementor determines the unique criteria. search_key columns are most appropriate for tables that maintain a primary concept but the record is not considered transactional. Examples of non-transactional records include users, business partners, and products.
-- `value` - text that is often used along with a `search_key` in a key-value pair.
-- `docno` - user defined text. The purpose of this column is to allow the system to auto-populate auto-incrementing document numbers. It is up to the implementor to determine if the document_no should be unique. If it should be unique, the implementor determines the unique criteria. The document_no column is most appropriate for tables that represent transactional data. Examples of a transaction records include invoices, orders, and payments. Tables that have a search_key column will not have a document_no column. The opposite is also true. <!-- TODO: define and link implementor -->
+- `name` - `text` representing the name of the record.
+- `description` - `text` representing the description of the record.
+- `search_key` - user defined `text`. The purpose of this column is to allow users to create keys that are more easily remembered by humans. It is up to the implementor to determine if the search_key should be unique for any given table. If it should be unique, the implementor determines the unique criteria. search_key columns are most appropriate for tables that maintain a primary concept but the record is not considered transactional. Examples of non-transactional records include users, business partners, and products.
+- `value` - `text` that is often used along with a `search_key` in a key-value pair.
+- `docno` - user defined `text`. The purpose of this column is to allow the system to auto-populate auto-incrementing document numbers. It is up to the implementor to determine if the document_no should be unique. If it should be unique, the implementor determines the unique criteria. The document_no column is most appropriate for tables that represent transactional data. Examples of a transaction records include invoices, orders, and payments. Tables that have a search_key column will not have a document_no column. The opposite is also true. <!-- TODO: define and link implementor -->
 - `type_enum` - a type table's reference to its enum value. ([see enum and type convetion](./enum-type-convention.md))
 - `type_uu` - references the record's associated type record.
 - `parent_uu` - references a record in the same table identified as being a parent.
@@ -51,6 +51,6 @@ The purpose of this section is to list the columns you commonly find in chuck-st
 - `is_include` - boolean that indicates if a record is of type include. Including a record could potentially impact all records that are not included. Said another way, including a record could potentially exclude all other records.
 - `is_exclude` - boolean that indicates if a record is of type exclude. Excluding a record only impacts that specified record.
 - `is_singleton` - indicates that only a single record or object should exist for group or category. Used for example to indicate if more than one attribute tag is allowed for given combination of table_name, uu, stk_attribute_tag_type_uu. If `is_singleton`=Y, then only one instance of an attribute tag type is allowed per record.
-- `batch_id` - text indicating this record was processed as part of a batch operation. A single record couple participate in multiple batches. if so, use the noun_adjective approach (example: batch_import_id).
-- `table_name` - text referencing the name of a table. This column is often generated.
-- `column_name` - text referencing the name of a column.
+- `batch_id` - `text` indicating this record was processed as part of a batch operation. A single record couple participate in multiple batches. if so, use the noun_adjective approach (example: batch_import_id).
+- `table_name` - `text` referencing the name of a table. This column is often generated.
+- `column_name` - `text` referencing the name of a column.

--- a/src-ls/postgres-convention/function-convention.md
+++ b/src-ls/postgres-convention/function-convention.md
@@ -3,6 +3,6 @@
 - All core chuck-stack function names should be `stk_`
 - The function name should use a noun + verb format to describe its behavior
 - An example function name: `stk_table_type_create`
-- All function parameter names should end with `_p` suffix. For example: name_p
-- All function declared variable names should end with `_v` suffix. For example: name_v
+- All function parameter names should end with `_p` suffix. For example: `name_p`
+- All function declared variable names should end with `_v` suffix. For example: `name_v`
  <!-- - concept of function => create_from vs create_into -- attempt to support both when possible - TODO: better define these terms -->

--- a/src-ls/postgres-convention/json-array-table-column.md
+++ b/src-ls/postgres-convention/json-array-table-column.md
@@ -3,8 +3,8 @@
 When extending any model, you must decide how you wish to extend the model. Historically, you would add an extra column or table for every incremental unit of data. Examples include adding a `color` or `height` column to a product table. This concept has challenges:
 
 - You can easily add hundreds of columns to a table for seldom used attributes.
-- The database becomes more complicated with ever column and table added.
-- Complicated databases are more difficult to maintains and reason about.
+- The database becomes more complicated with every column and table added.
+- Complicated databases are more difficult to maintain and reason about.
 
 ## Array Usage
 Instead of adding a traditional table or a link table to associate concepts in a one-to-many scenario, you can use an array of objects. The `private.stk_trigger_mgt` table uses this concept by creating a `table_name` TEXT[] column the holds an array of table names to drive what tables get what triggers.
@@ -66,8 +66,8 @@ This additional requirement allows us to use features like [attribute tagging](.
 
 ## JSON Type
 
-We make heave use of the JSON schema standard to validate the proper use and structure of stored JSON objects.
+We make heavy use of the JSON schema standard to validate the proper use and structure of stored JSON objects.
 
 The [attribute tag](./attribute-tag.md) architecture is a example use case of this schema standard so that we may represent complex data in a simplified manner. It is also an example of the [enum + type](./enum-type-convention.md) convention where the type record (`stk_attribute_tag_type_json` column) contains the JSON schema definition and the actual `stk_attribute_tag` table (`stk_attribute_tag_json` column) contains the instance or actual value of that JSON schema.
 
-The above reference videos help illustrate these concepts.
+The [above referenced videos](#json-references) help illustrate these concepts.

--- a/src-ls/postgres-convention/request.md
+++ b/src-ls/postgres-convention/request.md
@@ -10,6 +10,6 @@ The chuck-stack workflow is build around PostgreSQL tables, foreign keys, trigge
 
 Here are some details about the request architecture:
 
-- Requests are stored in stk_request
+- Requests are stored in `stk_request`
 - A request can exist in isolation of either other record
 - A request can be linked to any other record in the chuck-stack using the [table and record](./table-record-convention.md#linking-convention)

--- a/src-ls/postgres-convention/table-convention.md
+++ b/src-ls/postgres-convention/table-convention.md
@@ -5,7 +5,7 @@ This section discuss how we create tables in the private schema.
 - uuid single primary key
   - see [uuid page](./uuid.md) for more information about why and how we implement this standard.
   - See the [Table and Record Reference](./table-record-convention.md) section for more information.
-- Noun first table names - when naming tables the noun comes first and the adjective comes next. Example: stk_order_line and stk_order_tax where order is the noun and line and tax are the adjectives. The benefit of this approach is that like tables appear next to each other alphabetically. 
+- Noun first table names - when naming tables the noun comes first and the adjective comes next. Example: `stk_order_line` and `stk_order_tax` where order is the noun and line and tax are the adjectives. The benefit of this approach is that like tables appear next to each other alphabetically. 
 - `stk_` prefix - all core chuck-stack tables will begin with `stk_`. Example: `stk_bp`.
   - Your organization should chose a table prefix that resembles your organization's name if you wish to add new tables or new columns. Example: the Good-Care Medical organization could have a prefix of `gcm_`.
 - `_lnk` link table suffix - link tables should have a table name suffix of `_lnk`.

--- a/src-ls/postgres-convention/trigger-convention.md
+++ b/src-ls/postgres-convention/trigger-convention.md
@@ -64,4 +64,4 @@ Here are some utility functions to help make managing triggers easier.
 
 There are times when a single trigger function needs to be associated with many tables.
 
-To make managing the trigger creation in this scenario easier, there exists a private.stk_trigger_create() function that will create all applicable triggers as described by records in the private.stk_trigger_mgt table.
+To make managing the trigger creation in this scenario easier, there exists a `private.stk_trigger_create()` function that will create all applicable triggers as described by records in the `private.stk_trigger_mgt` table.

--- a/src-ls/postgres-conventions.md
+++ b/src-ls/postgres-conventions.md
@@ -4,8 +4,8 @@ The chuck-stack PostgreSQL conventions aim to create a consistent, convention-ba
 
 We provide two high-level features by which most applications are built:
 
-- Workflow - build around the stk_wf_request table and surrounding architecture
-- Attribute Tagging - build around the stk_attribute_tag architecture
+- Workflow - build around the `stk_wf_request` table and surrounding architecture
+- Attribute Tagging - build around the `stk_attribute_tag` architecture
 
 The below [convention summary](#convention-summary) creates a workflow and attributing tagging system that is both:
 

--- a/src-ls/postgres-conventions.md
+++ b/src-ls/postgres-conventions.md
@@ -31,7 +31,7 @@ Here is a summary of our conventions. Click on any link to learn more.
    - Public API schema (`api`) to expose a public interface providing data and logic to the outside world in a controlled way
 
 2. Table Conventions:
-   - Use a single UUID primary key column with a `<table_name>_uu` convention to support universal `table_name` + `record_uu` lookup across all tables
+   - Use a single UUID primary key column named `uu` to support universal `table_name` + `record_uu` lookup across all tables
    - Prefix core tables with `stk_`
    - Use noun-first naming (e.g., `stk_order_line`)
    - Minimize abbreviations to a known list to ensure maximum schema readability
@@ -40,7 +40,7 @@ Here is a summary of our conventions. Click on any link to learn more.
    - Use mandatory columns: `stk_entity_uu`,`created`,`created_by_uu`,`updated`,`updated_by_uu`.
    - All madatory columns are set automatically during save because of either default value or triggers
    - All tables return automatically generated `table_name` and `record_uu` columns for easy and generic looks for attributes, statistics, change logs, ...
-   - Use `_uu` suffix for primary and foreign keys
+   - Use `_uu` suffix for foreign keys
    - Use `text` type instead of `varchar` when possible
    - Boolean columns must have default values
 

--- a/src-ls/postgres-conventions.md
+++ b/src-ls/postgres-conventions.md
@@ -46,7 +46,7 @@ Here is a summary of our conventions. Click on any link to learn more.
 
 4. Enum and Type Conventions:
    - Most important tables have have a supporting `_type` table where users can describe that record's behavior
-   - Example: stk_actor table has a stk_actor_type table that describes the type of actor
+   - Example: `stk_actor` table has a `stk_actor_type` table that describes the type of actor
    - `_type` tables use enums for code-level logic
    - No `_uu` references should be made from code
    - Only enums should be referenced from code


### PR DESCRIPTION
Changed where table primary key included tablename to be simply `uu`.

Minor formatting and spelling changes.

Note, all changes only to markdown, not propogated to html yet.